### PR TITLE
Remove specialist contact buttons

### DIFF
--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -173,8 +173,7 @@ npm run preview
 
 ### CTAs Principais
 1. **"Quero garantir minha inscrição"** - CTA primário
-2. **"Falar com Especialista"** - CTA secundário
-3. **"Quero me tornar aluno"** - CTA alternativo
+2. **"Quero me tornar aluno"** - CTA alternativo
 
 ### Elementos de Conversão
 - Urgência: Contador regressivo

--- a/src/components/sections/CTASection.jsx
+++ b/src/components/sections/CTASection.jsx
@@ -117,13 +117,6 @@ const CTASection = () => {
                   </button>
                 }
               />
-              <LeadFormModal
-                trigger={
-                  <button className="border-2 border-white text-white px-12 py-4 rounded-xl font-bold text-lg hover:bg-white hover:text-red-600 transition-colors">
-                    Falar com Especialista
-                  </button>
-                }
-              />
             </div>
           </div>
 

--- a/src/components/sections/FAQSection.jsx
+++ b/src/components/sections/FAQSection.jsx
@@ -110,13 +110,6 @@ const FAQSection = () => {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <LeadFormModal
                 trigger={
-                  <button className="bg-white text-red-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
-                    Falar com Especialista
-                  </button>
-                }
-              />
-              <LeadFormModal
-                trigger={
                   <button className="border-2 border-white text-white px-8 py-3 rounded-lg font-semibold hover:bg-white hover:text-red-600 transition-colors">
                     Enviar Mensagem
                   </button>


### PR DESCRIPTION
## Summary
- drop “Falar com Especialista” CTA from FAQ section
- drop specialist contact button from main CTA block
- update docs to reflect the remaining primary and alternative CTAs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df3207360833280240aa1b8f1a49e