### PR TITLE
feat: add feedback to lead form modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import FeaturesSection from './components/sections/FeaturesSection';
 import TestimonialsSection from './components/sections/TestimonialsSection';
 import FAQSection from './components/sections/FAQSection';
 import CTASection from './components/sections/CTASection';
+import { Toaster } from './components/ui/sonner';
 import './App.css';
 
 function App() {
@@ -17,8 +18,9 @@ function App() {
         <TestimonialsSection />
         <CTASection />
         <FAQSection />
-        
+
       </main>
+      <Toaster position="top-center" richColors />
     </div>
   );
 }

--- a/src/components/common/LeadFormModal.jsx
+++ b/src/components/common/LeadFormModal.jsx
@@ -13,13 +13,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { User, Phone, Mail, UserPlus } from 'lucide-react';
+import { toast } from 'sonner';
 
 const LeadFormModal = ({ trigger }) => {
   const [open, setOpen] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const formData = new FormData(e.target);
+    const formData = new FormData(e.currentTarget);
     const urlParams = new URLSearchParams(window.location.search);
     const payload = {
       name: formData.get('name'),
@@ -34,16 +35,21 @@ const LeadFormModal = ({ trigger }) => {
     };
 
     try {
-      await fetch('https://projetolm-n8n.8x0hqh.easypanel.host/webhook/payload', {
+      const response = await fetch('https://projetolm-n8n.8x0hqh.easypanel.host/webhook/payload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      if (!response.ok) {
+        throw new Error('Erro ao enviar formulário');
+      }
+      toast.success('Formulário enviado com sucesso!');
+      e.currentTarget.reset();
+      setOpen(false);
     } catch (error) {
       console.error('Erro ao enviar formulário', error);
+      toast.error('Não foi possível enviar. Tente novamente.');
     }
-
-    setOpen(false);
   };
 
   return (


### PR DESCRIPTION
## Summary
- show toast feedback after lead form submission
- add app-wide toaster component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f600da6788332905466eb2afd71bc