### PR TITLE
Improve modal responsiveness

### DIFF
--- a/src/components/common/LeadFormModal.jsx
+++ b/src/components/common/LeadFormModal.jsx
@@ -49,14 +49,14 @@ const LeadFormModal = ({ trigger }) => {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="sm:max-w-md rounded-2xl border border-red-100 p-8 shadow-xl">
+      <DialogContent className="sm:max-w-md rounded-2xl border border-red-100 p-6 sm:p-8 shadow-xl">
         <img
           src="/logo-vertical.png"
           alt="Formação Paciente Grave"
           className="mx-auto mb-4 h-20 w-auto"
         />
         <DialogHeader className="text-center">
-          <DialogTitle className="flex items-center justify-center gap-2 text-2xl font-bold text-red-600">
+          <DialogTitle className="flex items-center justify-center gap-2 text-xl sm:text-2xl font-bold text-red-600">
             <UserPlus className="h-6 w-6" />
             Deixe seus dados
           </DialogTitle>
@@ -88,7 +88,7 @@ const LeadFormModal = ({ trigger }) => {
           </div>
           <div className="space-y-2">
             <Label>Sexo</Label>
-            <RadioGroup name="gender" className="flex gap-4">
+            <RadioGroup name="gender" className="flex flex-col gap-2 sm:flex-row sm:gap-4">
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="masculino" id="gender-masculino" />
                 <Label htmlFor="gender-masculino">Masculino</Label>


### PR DESCRIPTION
## Summary
- reduce modal padding on small screens
- make modal title and gender options responsive for mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e2275e2dc8332bacb5b84b9c2e262