### PR TITLE
Fix form reset after async submit

### DIFF
--- a/src/components/common/LeadFormModal.jsx
+++ b/src/components/common/LeadFormModal.jsx
@@ -20,7 +20,8 @@ const LeadFormModal = ({ trigger }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
     const urlParams = new URLSearchParams(window.location.search);
     const payload = {
       name: formData.get('name'),
@@ -44,7 +45,7 @@ const LeadFormModal = ({ trigger }) => {
         throw new Error('Erro ao enviar formulário');
       }
       toast.success('Formulário enviado com sucesso!');
-      e.currentTarget.reset();
+      form?.reset();
       setOpen(false);
     } catch (error) {
       console.error('Erro ao enviar formulário', error);


### PR DESCRIPTION
## Summary
- ensure LeadFormModal captures form element before asynchronous request
- reset form after successful submission to prevent null reference errors

## Testing
- `pnpm run test` (fails: Missing script: test)
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f64dccf988332a9fa3dc02625d08f